### PR TITLE
build(deps): bump django from 5.0.11 to 5.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
-django==5.0.11
+django==5.0.14
 python-dotenv==1.0.0
 mozilla-django-oidc==4.0.0


### PR DESCRIPTION
Dependabot fails to update to 5.0.14 to solve the latest issues